### PR TITLE
chore: update filament minimum version to 4.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "require": {
         "php": "^8.1",
-        "filament/support": "self.version",
+        "filament/support": "4.x-dev",
         "illuminate/support": "^10.45|^11.0|^12.0",
         "spatie/laravel-translatable": "^6.0"
     },


### PR DESCRIPTION
Due to some tests that need to be performed before the new Filament version is released, I'm updating the minimum requirements here, so it can be used with Filament `4.x-dev`.